### PR TITLE
Remove deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules
 *~
+\#*\#

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Twiglet: Node.js version
 
-![Node.js CI](https://github.com/simplybusiness/twiglet-node/workflows/Node.js%20CI/badge.svg?branch=master)
+Like a log, only smaller.
 
 This library provides a minimal JSON logging interface suitable for use in (micro)services. See the [RATIONALE](RATIONALE.md) for design rationale and an explantion of the Elastic Common Schema that we are using for log attribute naming.
+
+![Node.js CI](https://github.com/simplybusiness/twiglet-node/workflows/Node.js%20CI/badge.svg?branch=master)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Node.js CI](https://github.com/simplybusiness/twiglet-node/workflows/Node.js%20CI/badge.svg?branch=master)
 
-This library provides a minimal JSON logging interface suitable for use in (micro)services. See the [README](RATIONALE.md) for design rationale and an explantion of the Elastic Common Schema that we are using for log attribute naming.
+This library provides a minimal JSON logging interface suitable for use in (micro)services. See the [RATIONALE](RATIONALE.md) for design rationale and an explantion of the Elastic Common Schema that we are using for log attribute naming.
 
 ## Installation
 

--- a/json-helper.js
+++ b/json-helper.js
@@ -1,4 +1,4 @@
-const merge = require('deepmerge')
+const merge = require('./merge')
 
 const json_helper = (json) => {
   return Object.keys(json).reduce((acc, cur) => {

--- a/merge.js
+++ b/merge.js
@@ -1,0 +1,26 @@
+// Note, this deep-merges objects only and not arrays
+// All other types (arrays, strings, numbers, booleans) will
+// overwrite the first object's attribute with the second's.
+const merge = (x, y) => {
+  if (typeof(x) === 'object' &&
+      Array.isArray(x) !== true &&
+      typeof(y) === 'object' &&
+      Array.isArray(y) !== true) {
+    // both are objects, merge y into x
+    var result = x
+
+    for (var a in y) {
+      if (typeof(x[a]) === 'object' && typeof(y[a]) === 'object') {
+        result[a] = merge(x[a], y[a])
+      } else {
+        result[a] = y[a]
+      }
+    }
+
+    return result
+  } else {
+    return y
+  }
+}
+
+module.exports = merge

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -57,11 +57,6 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A simple JSON-logging micro-library for services",
   "main": "logger.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple JSON-logging micro-library for services",
   "main": "logger.js",
   "scripts": {
-    "test": "jshint *.js && jasmine spec/*spec.js"
+    "test": "jshint *.js && jasmine spec/*.js"
   },
   "repository": {
     "type": "git",
@@ -35,7 +35,5 @@
     "esversion": 10,
     "asi": true
   },
-  "dependencies": {
-    "deepmerge": "4.x"
-  }
+  "dependencies": {}
 }

--- a/spec/merge_test.js
+++ b/spec/merge_test.js
@@ -1,0 +1,38 @@
+const merge = require('../merge')
+
+describe('An object munger', () => {
+  it('should merge two empty objects', () => {
+    expect(merge({}, {})).toEqual({})
+  })
+
+  it('should not merge something that isn\'t an object', () => {
+    expect(merge(1, {})).toEqual({})
+    expect(merge({}, 'thing')).toEqual('thing')
+  })
+
+  it('should merge two objects with different properties', () => {
+    expect(merge({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 })
+  })
+
+  it('should override a first attribute with a second', () => {
+    expect(merge({ a: 1 }, { a: 2 })).toEqual({ a: 2 })
+  })
+
+  it('should deep merge attributes that are objects', () => {
+    first =    { a: { a: 1 }, b: 2 }
+    second =   { a: { b: 1 }, b: 3, c: 1 }
+    expected = { a: { a: 1, b: 1 }, b: 3, c: 1 }
+    expect(merge(first, second)).toEqual(expected)
+  })
+
+  it('should even deeper merge attributes that are objects', () => {
+    first =    { a: { a: 1, x: { a: true }}, b: 2 }
+    second =   { a: { b: 1, x: { b: 'x' }}, b: 3, c: 1 }
+    expected = { a: { a: 1, b: 1, x: { a: true, b: 'x' }}, b: 3, c: 1 }
+    expect(merge(first, second)).toEqual(expected)
+  })
+
+  it('should overwrite an array with an object', ()  => {
+    expect(merge({ a: [1, 2]}, { a: { x: 3 }})).toEqual({ a: { x: 3 }})
+  })
+})


### PR DESCRIPTION
This removes the last (and only) npm dependency for this project: `deepmerge`.
If and when the json_helper is no longer needed, the merge.js file can also be removed.