### PR TITLE
Simplify interface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Add your project owners info here
+# More information: https://help.github.com/articles/about-codeowners/
+* @simplybusiness/application-tooling

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create a new logger like so:
 
 ```javascript
 const Logger = require('@simplybusiness/twiglet')
-const log = Logger('petshop')
+const log = Logger('service-name')
 ```
 
 The logger may be passed in the configuration object an optional output attribute which should be an object with a 'log' method - like `console`. The configuration object may also have an optional now atttribute, which should be a function that returns an ISO 8601 compliant datetimestamp. The defaults should serve for most uses, though you may want to override them for testing as we have done [here](./spec/logger-spec.js).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create a new logger like so:
 
 ```javascript
 const Logger = require('@simplybusiness/twiglet')
-const log = Logger({ service: 'petshop' })
+const log = Logger('petshop')
 ```
 
 The logger may be passed in the configuration object an optional output attribute which should be an object with a 'log' method - like `console`. The configuration object may also have an optional now atttribute, which should be a function that returns an ISO 8601 compliant datetimestamp. The defaults should serve for most uses, though you may want to override them for testing as we have done [here](./spec/logger-spec.js).

--- a/example-app.js
+++ b/example-app.js
@@ -2,16 +2,12 @@ const Logger = require('@simplybusiness/twiglet')
 
 const PORT = 8080
 
-const log = Logger({
-  now: Date.now,
-  output: console,
-  service: "petshop"
-})
+const log = Logger('petshop')
 
 // Start our petshop
 log.info({
   event: {
-    action: "startup"
+    action: 'startup'
   },
   message: `Ready to go, listening on port ${PORT}`,
   server: {
@@ -20,16 +16,16 @@ log.info({
 })
 
 // We get a request
-const requestLog = log.with({ event: { action: "HTTP request" }, trace: { id: "126bb6fa-28a2-470f-b013-eefbf9182b2d" }})
+const requestLog = log.with({ event: { action: 'HTTP request' }, trace: { id: '126bb6fa-28a2-470f-b013-eefbf9182b2d' }})
 
 // Oh noes!
 dbErr = true // this time!
 if (dbErr) {
-  requestLog.error({ message: "DB connection failed." })
+  requestLog.error({ message: 'DB connection failed.' })
 }
 
 // We return an error to the requester
-requestLog.info({ message: "Internal Server Error", http: { request: { method: 'get'}, response: { status_code: 500 }}})
+requestLog.info({ message: 'Internal Server Error', http: { request: { method: 'get'}, response: { status_code: 500 }}})
 
 // Logging with a non-empty message is an anti-pattern and is therefore forbidden
 // Both of the following lines would throw an error

--- a/example-express-app.js
+++ b/example-express-app.js
@@ -1,18 +1,18 @@
 // Imports
-const Logger = require("@simplybusiness/twiglet")
-const express = require("express")
+const Logger = require('@simplybusiness/twiglet')
+const express = require('express')
 
 // Constants
 const PORT = 8080
 
 // Define a logger
-const log = Logger({ service: "petshop" })
+const log = Logger('petshop')
 
 // Define some express middleware
 const loggingMiddleware = (req, res, next) => {
   log.info({
-    event: { action: "http request" },
-    message: "request received",
+    event: { action: 'http request' },
+    message: 'request received',
     http: {
       url: {
         path: req.path,
@@ -33,7 +33,7 @@ const errorHandler = (err, req, res, next) => {
   // Probably no need for URL/request info here as request
   // already logged by previous middleware
   log.error({
-    message: "Error",
+    message: 'Error',
     response: { status_code: 500 }}, err)
   res.status(500)
   res.render('An error has occurred')
@@ -44,12 +44,12 @@ var app = express()
 
 app.use(loggingMiddleware)
 
-app.get("/", (req, res) => {
-  res.send("This is the home Page")
+app.get('/', (req, res) => {
+  res.send('This is the home Page')
 })
 
-app.get("/broken", (req, res) => {
-  throw(new Error("Emergency!"))
+app.get('/broken', (req, res) => {
+  throw(new Error('Emergency!'))
 })
 
 app.use(errorHandler)
@@ -57,7 +57,7 @@ app.use(errorHandler)
 // Start our petshop
 app.listen(PORT, () => {
   log.info({
-    event: { action: "startup" },
+    event: { action: 'startup' },
     message: `Ready to go, listening on port ${PORT}`,
     server: { port: PORT }
   })

--- a/logger.js
+++ b/logger.js
@@ -19,11 +19,11 @@
 const assert = require('assert')
 const jsonHelper = require('./json-helper')
 
-const Logger = (service_name,
+const Logger = (serviceName,
                 defaultProperties = {},
                 now = null,
                 output = console) => {
-  assert.equal(typeof(service_name), 'string',
+  assert.equal(typeof(serviceName), 'string',
                'configuration must have a service name')
   if (typeof(now) != 'function') { now = () => (new Date()).toISOString() }
   if (typeof(output) != 'object' || typeof(output.log) != 'function') {
@@ -52,7 +52,7 @@ const Logger = (service_name,
                                  stacktrace: err.stack.split('\n') }}}
     const totalMessage = { ...{ log: { level: severity },
                                  '@timestamp': now(),
-                                 service: { name: service_name }},
+                                 service: { name: serviceName }},
                             ...defaultProperties,
                             ...errorMessage,
                             ...message }
@@ -63,7 +63,7 @@ const Logger = (service_name,
   return {
     now: now,
     output: output,
-    service_name: service_name,
+    serviceName: serviceName,
     defaultProperties: defaultProperties,
     debug: log.bind(null, 'debug'),
     info: log.bind(null, 'info'),
@@ -72,7 +72,7 @@ const Logger = (service_name,
     error: log.bind(null, 'error'),
     critical: log.bind(null, 'critical'),
     with: (moreProperties) => {
-      return Logger(service_name,
+      return Logger(serviceName,
                     {...defaultProperties,
                      ...moreProperties},
                     now,

--- a/logger.js
+++ b/logger.js
@@ -19,11 +19,11 @@
 const assert = require('assert')
 const jsonHelper = require('./json-helper')
 
-const Logger = (conf, scopedProperties) => {
-  assert.equal(typeof(conf.service), 'string',
+const Logger = (service, conf, scopedProperties) => {
+  assert.equal(typeof(service), 'string',
                'configuration must have a service name')
 
-  var { now, output, service } = conf
+  var { now, output } = conf
   if (typeof(now) != 'function') { now = () => (new Date()).toISOString() }
   if (typeof(output) != 'object' || typeof(output.log) != 'function') {
     output = console
@@ -70,7 +70,8 @@ const Logger = (conf, scopedProperties) => {
     error: log.bind(null, 'error'),
     critical: log.bind(null, 'critical'),
     with: (moreProperties) => {
-      return Logger(conf,
+      return Logger(service,
+                    conf,
                     {...scopedProperties,
                      ...moreProperties})
     } // end .with

--- a/logger.js
+++ b/logger.js
@@ -68,6 +68,7 @@ const Logger = (service_name,
     debug: log.bind(null, 'debug'),
     info: log.bind(null, 'info'),
     warning: log.bind(null, 'warning'),
+    warn: log.bind(null, 'warning'),
     error: log.bind(null, 'error'),
     critical: log.bind(null, 'critical'),
     with: (moreProperties) => {

--- a/logger.js
+++ b/logger.js
@@ -49,7 +49,7 @@ const Logger = (serviceName,
     var errorMessage = {}
     if (err) {
       errorMessage = { error: { message: err.message,
-                                 stacktrace: err.stack.split('\n') }}}
+                                stack_trace: err.stack.split('\n') }}}
     const totalMessage = { ...{ log: { level: severity },
                                  '@timestamp': now(),
                                  service: { name: serviceName }},

--- a/logger.js
+++ b/logger.js
@@ -19,11 +19,12 @@
 const assert = require('assert')
 const jsonHelper = require('./json-helper')
 
-const Logger = (service, conf, scopedProperties) => {
-  assert.equal(typeof(service), 'string',
+const Logger = (service_name,
+                defaultProperties = {},
+                now = null,
+                output = console) => {
+  assert.equal(typeof(service_name), 'string',
                'configuration must have a service name')
-
-  var { now, output } = conf
   if (typeof(now) != 'function') { now = () => (new Date()).toISOString() }
   if (typeof(output) != 'object' || typeof(output.log) != 'function') {
     output = console
@@ -51,8 +52,8 @@ const Logger = (service, conf, scopedProperties) => {
                                  stacktrace: err.stack.split('\n') }}}
     const totalMessage = { ...{ log: { level: severity },
                                  '@timestamp': now(),
-                                 service: { name: service }},
-                            ...scopedProperties,
+                                 service: { name: service_name }},
+                            ...defaultProperties,
                             ...errorMessage,
                             ...message }
     const nestedMessage = jsonHelper(totalMessage)
@@ -62,18 +63,19 @@ const Logger = (service, conf, scopedProperties) => {
   return {
     now: now,
     output: output,
-    service: service,
-    scopedProperties: scopedProperties,
+    service_name: service_name,
+    defaultProperties: defaultProperties,
     debug: log.bind(null, 'debug'),
     info: log.bind(null, 'info'),
     warning: log.bind(null, 'warning'),
     error: log.bind(null, 'error'),
     critical: log.bind(null, 'critical'),
     with: (moreProperties) => {
-      return Logger(service,
-                    conf,
-                    {...scopedProperties,
-                     ...moreProperties})
+      return Logger(service_name,
+                    {...defaultProperties,
+                     ...moreProperties},
+                    now,
+                    output)
     } // end .with
   } // end return
 } // end Logger

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A simple JSON-logging micro-library for services",
   "main": "logger.js",
   "scripts": {

--- a/spec/json-helper-spec.js
+++ b/spec/json-helper-spec.js
@@ -1,95 +1,95 @@
-const jasmine = require("jasmine")
-const json_helper = require("../json-helper")
+const jasmine = require('jasmine')
+const json_helper = require('../json-helper')
 
-describe("json_helper", () => {
-  it("should retain an object without . in any keys", () => {
+describe('json_helper', () => {
+  it('should retain an object without . in any keys', () => {
     const before = {
-      message: "Out of pets exception",
+      message: 'Out of pets exception',
       service: {
-        name: "petshop"
+        name: 'petshop'
       },
       log: {
-        level: "error"
+        level: 'error'
       },
-      "@timestamp": "2020-05-09T15:13:20.736Z"
+      '@timestamp': '2020-05-09T15:13:20.736Z'
     }
 
     const after = json_helper(before)
     expect(before).toEqual(after)
   })
 
-  it("should convert keys with . into nested objects", () => {
+  it('should convert keys with . into nested objects', () => {
     const before = {
-      message: "Out of pets exception",
-      "service.name": "petshop",
-      "log.level": "error",
-      "@timestamp": "2020-05-09T15:13:20.736Z"
+      message: 'Out of pets exception',
+      'service.name': 'petshop',
+      'log.level': 'error',
+      '@timestamp': '2020-05-09T15:13:20.736Z'
     }
 
     const after = {
-      message: "Out of pets exception",
+      message: 'Out of pets exception',
       service: {
-        name: "petshop"
+        name: 'petshop'
       },
       log: {
-        level: "error"
+        level: 'error'
       },
-      "@timestamp": "2020-05-09T15:13:20.736Z"
+      '@timestamp': '2020-05-09T15:13:20.736Z'
     }
 
     expect(json_helper(before)).toEqual(after)
   })
 
-  it("should group nested objects", () => {
+  it('should group nested objects', () => {
     const before = {
-      message: "Out of pets exception",
-      "service.name": "petshop",
-      "service.id": "ps001",
-      "service.version": "0.9.1",
-      "log.level": "error",
-      "@timestamp": "2020-05-09T15:13:20.736Z"
+      message: 'Out of pets exception',
+      'service.name': 'petshop',
+      'service.id': 'ps001',
+      'service.version': '0.9.1',
+      'log.level': 'error',
+      '@timestamp': '2020-05-09T15:13:20.736Z'
     }
 
     const after = {
-      message: "Out of pets exception",
+      message: 'Out of pets exception',
       service: {
-        id: "ps001",
-        name: "petshop",
-        version: "0.9.1"
+        id: 'ps001',
+        name: 'petshop',
+        version: '0.9.1'
       },
       log: {
-        level: "error"
+        level: 'error'
       },
-      "@timestamp": "2020-05-09T15:13:20.736Z"
+      '@timestamp': '2020-05-09T15:13:20.736Z'
     }
 
     expect(json_helper(before)).toEqual(after)
   })
 
-  it("should cope with more than two levels", () => {
+  it('should cope with more than two levels', () => {
     const before = {
-      message: "Escaped pet situation",
-      "service.name": "petshop",
-      "log.level": "debug",
-      "@timestamp": "2020-05-09T15:13:20.736Z",
-      "http.request.method": "get",
-      "http.request.body.bytes": 112,
-      "http.response.bytes": 1564,
-      "http.response.status_code": 200
+      message: 'Escaped pet situation',
+      'service.name': 'petshop',
+      'log.level': 'debug',
+      '@timestamp': '2020-05-09T15:13:20.736Z',
+      'http.request.method': 'get',
+      'http.request.body.bytes': 112,
+      'http.response.bytes': 1564,
+      'http.response.status_code': 200
     }
 
     const after = {
-      message: "Escaped pet situation",
+      message: 'Escaped pet situation',
       service: {
-        name: "petshop"
+        name: 'petshop'
       },
       log: {
-        level: "debug"
+        level: 'debug'
       },
-      "@timestamp": "2020-05-09T15:13:20.736Z",
+      '@timestamp': '2020-05-09T15:13:20.736Z',
       http: {
         request: {
-          method: "get",
+          method: 'get',
           body: {
             bytes: 112
           }

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -1,5 +1,5 @@
 // Dependencies
-const Logger = require("../logger")
+const Logger = require('../logger')
 
 // Constants
 const DEBUG = process.env.DEBUG
@@ -7,7 +7,7 @@ const DEBUG = process.env.DEBUG
 // Helpers
 class FakeConsole {
   constructor () {
-    this.printed = ""
+    this.printed = ''
   }
 
   log (x) {
@@ -17,189 +17,189 @@ class FakeConsole {
 }
 
 // Tests
-describe("logging", () => {
+describe('logging', () => {
   beforeAll(() => {
     this.log = Logger({
-      now: () => "2016-02-15T12:34:56.789Z",
+      now: () => '2016-02-15T12:34:56.789Z',
       output: new FakeConsole(),
-      service: "petshop"
+      service: 'petshop'
     })
   })
 
-  it("should throw an error without a message", () => {
+  it('should throw an error without a message', () => {
     expect(() => {
       this.log.info()
     }).toThrow()
   })
 
-  it("should log mandatory attributes", () => {
-    this.log.error({ message: "Out of pets exception" })
+  it('should log mandatory attributes', () => {
+    this.log.error({ message: 'Out of pets exception' })
     const contents = JSON.parse(this.log.output.printed)
-    expect(contents["@timestamp"]).toBe("2016-02-15T12:34:56.789Z")
-    expect(contents.service.name).toBe("petshop")
-    expect(contents.log.level).toBe("error")
-    expect(contents.message).toBe("Out of pets exception")
+    expect(contents['@timestamp']).toBe('2016-02-15T12:34:56.789Z')
+    expect(contents.service.name).toBe('petshop')
+    expect(contents.log.level).toBe('error')
+    expect(contents.message).toBe('Out of pets exception')
   })
 
-  it("should log the provided message", () => {
-    this.log.error({ event: { action: "exception" }, message: "Emergency! Emergency!" })
+  it('should log the provided message', () => {
+    this.log.error({ event: { action: 'exception' }, message: 'Emergency! Emergency!' })
     const contents = JSON.parse(this.log.output.printed)
 
-    expect(contents.event.action).toBe("exception")
-    expect(contents.message).toBe("Emergency! Emergency!")
+    expect(contents.event.action).toBe('exception')
+    expect(contents.message).toBe('Emergency! Emergency!')
   })
 
-  it("should log a stack trace if provided", () => {
+  it('should log a stack trace if provided', () => {
     try {
       console.thing()
     } catch (err) {
-      this.log.error({ message: "An error!" }, err)
+      this.log.error({ message: 'An error!' }, err)
     }
     const contents = JSON.parse(this.log.output.printed)
 
-    expect(contents.message).toBe("An error!")
-    expect(contents.error.message).toBe("console.thing is not a function")
-    expect(contents.error.stacktrace[1]).toContain("logger-spec")
+    expect(contents.message).toBe('An error!')
+    expect(contents.error.message).toBe('console.thing is not a function')
+    expect(contents.error.stacktrace[1]).toContain('logger-spec')
   })
 
-  it("should log scoped properties defined at creation", () => {
+  it('should log scoped properties defined at creation', () => {
     const extraProperties = {
       trace: {
-        id: "1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb"
+        id: '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
       },
-      message: "GET /cats",
-      request: { method: "get" },
+      message: 'GET /cats',
+      request: { method: 'get' },
       response: { status_code: 200 }
     }
     const myLogger = Logger({
-      now: () => "2016-02-15T12:34:56.789Z",
+      now: () => '2016-02-15T12:34:56.789Z',
       output: new FakeConsole(),
-      service: "petshop"
+      service: 'petshop'
     }, extraProperties)
 
     myLogger.error(extraProperties)
     const contents = JSON.parse(myLogger.output.printed)
 
-    expect(contents.trace.id).toBe("1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb")
-    expect(contents.request.method).toBe("get")
+    expect(contents.trace.id).toBe('1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb')
+    expect(contents.request.method).toBe('get')
     expect(contents.response.status_code).toBe(200)
-    expect(contents.message).toBe("GET /cats")
+    expect(contents.message).toBe('GET /cats')
   })
 
   it("should be able to add properties with '.with'", () => {
     // Let's add some context to this customer journey
     const purchaseLog = this.log.with({
-      trace: { id: "1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb" },
-      customer: { full_name: "Freda Bloggs" },
-      event: { action: "pet purchase" }
+      trace: { id: '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb' },
+      customer: { full_name: 'Freda Bloggs' },
+      event: { action: 'pet purchase' }
     })
     // do stuff
     purchaseLog.info({
-      message: "customer bought a dog",
-      pet: { name: "Barker", species: "dog", breed: "Bitsa" }
+      message: 'customer bought a dog',
+      pet: { name: 'Barker', species: 'dog', breed: 'Bitsa' }
     })
     const contents = JSON.parse(purchaseLog.output.printed)
 
-    expect(contents.trace.id).toBe("1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb")
-    expect(contents.customer.full_name).toBe("Freda Bloggs")
-    expect(contents.event.action).toBe("pet purchase")
-    expect(contents.message).toBe("customer bought a dog")
-    expect(contents.pet.name).toBe("Barker")
+    expect(contents.trace.id).toBe('1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb')
+    expect(contents.customer.full_name).toBe('Freda Bloggs')
+    expect(contents.event.action).toBe('pet purchase')
+    expect(contents.message).toBe('customer bought a dog')
+    expect(contents.pet.name).toBe('Barker')
   })
 
-  it("should be able to convert dotted keys to nested objects", () => {
+  it('should be able to convert dotted keys to nested objects', () => {
     this.log.debug({
-      "trace.id": "1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb",
-      "customer.full_name": "Freda Bloggs",
-      "event.action": "pet purchase",
-      message: "customer bought a dog",
-      "pet.name": "Barker",
-      "pet.species": "dog",
-      "pet.breed": "Bitsa"
+      'trace.id': '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
+      'customer.full_name': 'Freda Bloggs',
+      'event.action': 'pet purchase',
+      message: 'customer bought a dog',
+      'pet.name': 'Barker',
+      'pet.species': 'dog',
+      'pet.breed': 'Bitsa'
     })
     const contents = JSON.parse(this.log.output.printed)
 
-    expect(contents.trace.id).toBe("1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb")
-    expect(contents.customer.full_name).toBe("Freda Bloggs")
-    expect(contents.event.action).toBe("pet purchase")
-    expect(contents.message).toBe("customer bought a dog")
-    expect(contents.pet.name).toBe("Barker")
-    expect(contents.pet.species).toBe("dog")
-    expect(contents.pet.breed).toBe("Bitsa")
+    expect(contents.trace.id).toBe('1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb')
+    expect(contents.customer.full_name).toBe('Freda Bloggs')
+    expect(contents.event.action).toBe('pet purchase')
+    expect(contents.message).toBe('customer bought a dog')
+    expect(contents.pet.name).toBe('Barker')
+    expect(contents.pet.species).toBe('dog')
+    expect(contents.pet.breed).toBe('Bitsa')
   })
 
-  it("should be able to mix dotted keys and nested objects", () => {
+  it('should be able to mix dotted keys and nested objects', () => {
     this.log.debug({
-      "trace.id": "1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb",
-      "customer.full_name": "Freda Bloggs",
-      "event.action": "pet purchase",
-      message: "customer bought a dog",
-      pet: { name: "Barker", breed: "Bitsa" },
-      "pet.species": "dog"
+      'trace.id': '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
+      'customer.full_name': 'Freda Bloggs',
+      'event.action': 'pet purchase',
+      message: 'customer bought a dog',
+      pet: { name: 'Barker', breed: 'Bitsa' },
+      'pet.species': 'dog'
     })
     const contents = JSON.parse(this.log.output.printed)
 
-    expect(contents.trace.id).toBe("1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb")
-    expect(contents.customer.full_name).toBe("Freda Bloggs")
-    expect(contents.event.action).toBe("pet purchase")
-    expect(contents.message).toBe("customer bought a dog")
-    expect(contents.pet.name).toBe("Barker")
-    expect(contents.pet.species).toBe("dog")
-    expect(contents.pet.breed).toBe("Bitsa")
+    expect(contents.trace.id).toBe('1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb')
+    expect(contents.customer.full_name).toBe('Freda Bloggs')
+    expect(contents.event.action).toBe('pet purchase')
+    expect(contents.message).toBe('customer bought a dog')
+    expect(contents.pet.name).toBe('Barker')
+    expect(contents.pet.species).toBe('dog')
+    expect(contents.pet.breed).toBe('Bitsa')
   })
 
-  describe("enforcing non-empty message", () => {
-    it("should throw an error on an empty message", () => {
+  describe('enforcing non-empty message', () => {
+    it('should throw an error on an empty message', () => {
       expect(() => {
-        this.log.info("")
+        this.log.info('')
       }).toThrow()
     })
 
-    it("should throw an error on a message of blank spaces", () => {
+    it('should throw an error on a message of blank spaces', () => {
       expect(() => {
-        this.log.info("     ")
+        this.log.info('     ')
       }).toThrow()
     })
 
-    it("should throw an error on a null message", () => {
+    it('should throw an error on a null message', () => {
       expect(() => {
         this.log.info(null)
       }).toThrow()
     })
 
-    it("should throw an error on an undefined message", () => {
+    it('should throw an error on an undefined message', () => {
       expect(() => {
         this.log.info(undefined)
       }).toThrow()
     })
 
-    it("should throw an error if message property is missing", () => {
+    it('should throw an error if message property is missing', () => {
       expect(() => {
-        this.log.debug({ event: { action: "pet purchase" }})
+        this.log.debug({ event: { action: 'pet purchase' }})
       }).toThrow()
     })
 
-    it("should throw an error on an undefined message as a property", () => {
+    it('should throw an error on an undefined message as a property', () => {
       expect(() => {
-        this.log.debug({ event: { action: "pet purchase" }, message: undefined })
+        this.log.debug({ event: { action: 'pet purchase' }, message: undefined })
       }).toThrow()
     })
 
-    it("should throw an error on an null message as a property", () => {
+    it('should throw an error on an null message as a property', () => {
       expect(() => {
-        this.log.debug({ event: { action: "pet purchase" }, message: null })
+        this.log.debug({ event: { action: 'pet purchase' }, message: null })
       }).toThrow()
     })
 
-    it("should throw an error on an empty message as a property", () => {
+    it('should throw an error on an empty message as a property', () => {
       expect(() => {
-        this.log.debug({ event: { action: "pet purchase" }, message: "" })
+        this.log.debug({ event: { action: 'pet purchase' }, message: '' })
       }).toThrow()
     })
 
-    it("should throw an error on an message of blank spaces as a property", () => {
+    it('should throw an error on an message of blank spaces as a property', () => {
       expect(() => {
-        this.log.debug({ event: { action: "pet purchase" }, message: "   " })
+        this.log.debug({ event: { action: 'pet purchase' }, message: '   ' })
       }).toThrow()
     })
   })

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -19,10 +19,9 @@ class FakeConsole {
 // Tests
 describe('logging', () => {
   beforeAll(() => {
-    this.log = Logger({
+    this.log = Logger('petshop', {
       now: () => '2016-02-15T12:34:56.789Z',
-      output: new FakeConsole(),
-      service: 'petshop'
+      output: new FakeConsole()
     })
   })
 
@@ -71,10 +70,9 @@ describe('logging', () => {
       request: { method: 'get' },
       response: { status_code: 200 }
     }
-    const myLogger = Logger({
+    const myLogger = Logger('petshop', {
       now: () => '2016-02-15T12:34:56.789Z',
-      output: new FakeConsole(),
-      service: 'petshop'
+      output: new FakeConsole()
     }, extraProperties)
 
     myLogger.error(extraProperties)

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -58,7 +58,7 @@ describe('logging', () => {
 
     expect(contents.message).toBe('An error!')
     expect(contents.error.message).toBe('console.thing is not a function')
-    expect(contents.error.stacktrace[1]).toContain('logger-spec')
+    expect(contents.error.stack_trace[1]).toContain('logger-spec')
   })
 
   it('should log scoped properties defined at creation', () => {

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -19,10 +19,10 @@ class FakeConsole {
 // Tests
 describe('logging', () => {
   beforeAll(() => {
-    this.log = Logger('petshop', {
-      now: () => '2016-02-15T12:34:56.789Z',
-      output: new FakeConsole()
-    })
+    this.log = Logger('petshop',
+                      {},
+                      () => '2016-02-15T12:34:56.789Z',
+                      new FakeConsole())
   })
 
   it('should throw an error without a message', () => {
@@ -70,11 +70,10 @@ describe('logging', () => {
       request: { method: 'get' },
       response: { status_code: 200 }
     }
-    const myLogger = Logger('petshop', {
-      now: () => '2016-02-15T12:34:56.789Z',
-      output: new FakeConsole()
-    }, extraProperties)
-
+    const myLogger = Logger('petshop',
+                            extraProperties,
+                            () => '2016-02-15T12:34:56.789Z',
+                            new FakeConsole())
     myLogger.error(extraProperties)
     const contents = JSON.parse(myLogger.output.printed)
 


### PR DESCRIPTION
This change moves the service name out of the configuration object and into the first parameter, simplifying the default way of instantiating a new Logger.
This is now consistent with twiglet-ruby.