### PR TITLE
Fix Github action so it run on all branches

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,13 +3,11 @@ name: Node.js CI
 on:
   push:
     branches:
-      - '*'         # matches every branch
-      - '*/*'       # matches every branch containing a single '/'
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [12.x, 14.x]


### PR DESCRIPTION
Dependabot creates branches with more than one backslashes so action wont run on those branches. 
This PR will fix this issue.

@simplybusiness/application-tooling 
