### PR TITLE
Add ECS_VERSION

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -18,6 +18,7 @@
 
 const assert = require('assert')
 const jsonHelper = require('./json-helper')
+const ECS_VERSION = '1.5.0'
 
 const Logger = (serviceName,
                 defaultProperties = {},
@@ -50,17 +51,19 @@ const Logger = (serviceName,
     if (err) {
       errorMessage = { error: { message: err.message,
                                 stack_trace: err.stack.split('\n') }}}
-    const totalMessage = { ...{ log: { level: severity },
-                                 '@timestamp': now(),
-                                 service: { name: serviceName }},
-                            ...defaultProperties,
-                            ...errorMessage,
-                            ...message }
+    const totalMessage = { ...{ ecs: { version: ECS_VERSION },
+                                log: { level: severity },
+                                '@timestamp': now(),
+                                service: { name: serviceName }},
+                           ...defaultProperties,
+                           ...errorMessage,
+                           ...message }
     const nestedMessage = jsonHelper(totalMessage)
     output.log(JSON.stringify(nestedMessage))
   }
 
   return {
+    ECS_VERSION: ECS_VERSION,
     now: now,
     output: output,
     serviceName: serviceName,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A simple JSON-logging micro-library for services",
   "main": "logger.js",
   "scripts": {

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -37,6 +37,7 @@ describe('logging', () => {
     expect(contents['@timestamp']).toBe('2016-02-15T12:34:56.789Z')
     expect(contents.service.name).toBe('petshop')
     expect(contents.log.level).toBe('error')
+    expect(contents.ecs.version).toBe(this.log.ECS_VERSION)
     expect(contents.message).toBe('Out of pets exception')
   })
 


### PR DESCRIPTION
This adds the `ecs.version` field to the mandatory logging outputs.