### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 99
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:30"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 99


### PR DESCRIPTION
This pull request adds a configuration file for Dependabot to automate dependency updates for npm packages and GitHub Actions workflows.

Dependency update automation:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R21): Configured Dependabot to check for updates to npm dependencies weekly and GitHub Actions workflows daily, specifying schedules, time zones, and limits for open pull requests.