### PR TITLE
bump the version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "jasmine": "5.x",
@@ -13,7 +13,7 @@
         "nyc": "17.x"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplybusiness/twiglet",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A simple JSON-logging micro-library for services",
   "main": "logger.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/simplybusiness/twiglet-node#readme",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "jasmine": "5.x",


### PR DESCRIPTION
This pull request updates the `@simplybusiness/twiglet` library to version `2.2.0`, including changes to dependencies and compatibility requirements. The most important changes involve updating the version number and increasing the minimum required Node.js version.

Version updates:

* [`npm-shrinkwrap.json`](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3-R16): Updated the library version from `2.1.1` to `2.2.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the library version from `2.1.1` to `2.2.0`.

Compatibility requirements:

* [`npm-shrinkwrap.json`](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3-R16): Increased the minimum required Node.js version from `>=12.0.0` to `>=18.0.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R29): Increased the minimum required Node.js version from `>=12.0.0` to `>=18.0.0`.