### PR TITLE
Update secret

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,4 +25,4 @@ jobs:
       - run: npm publish
         env:
           NODE_ENV: production
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.SB_PUBLISH_NPM_PACKAGE}}


### PR DESCRIPTION
This pull request updates the `.github/workflows/npm-publish.yml` workflow to use a more specific secret for publishing npm packages.

* `jobs:` in `.github/workflows/npm-publish.yml`: Replaced the `NODE_AUTH_TOKEN` secret from `secrets.NPM_TOKEN` to `secrets.SB_PUBLISH_NPM_PACKAGE` for better clarity and security in secret management.